### PR TITLE
Fix segfault on some problems

### DIFF
--- a/include/aptk/rp_iw.hxx
+++ b/include/aptk/rp_iw.hxx
@@ -48,7 +48,7 @@ public:
 	typedef 	Closed_List< Search_Node >			Closed_List_Type;
 
 	RP_IW( 	const Search_Model& search_problem ) 
-		: m_problem( search_problem ), m_exp_count(0), m_gen_count(0), m_cl_count(0), m_max_depth(0), m_pruned_B_count(0), m_B( infty ), m_use_relplan(true), m_goals(NULL), m_verbose(true) {	   
+		: m_problem( search_problem ), m_exp_count(0), m_gen_count(0), m_cl_count(0), m_max_depth(0), m_pruned_B_count(0), m_B( infty ), m_use_relplan(true), m_goals(NULL), m_verbose(true), m_init_pruned(false) {
 		m_novelty = new Abstract_Novelty( search_problem );
 		m_novelty->set_full_state_computation( false );
 		m_rp_h = new RP_Heuristic( search_problem );
@@ -57,6 +57,7 @@ public:
 
 	}
 
+	bool	init_pruned( ) { return m_init_pruned; }
 	bool	verbose( ) const { return m_verbose; }
 	void 	set_verbose( bool v ) { m_verbose = v; }
 	
@@ -191,6 +192,7 @@ public:
 		
 		if ( prune( this->m_root ) )  {
 			std::cout<<"Initial State pruned! No Solution found."<<std::endl;
+			m_init_pruned = true;
 			return;
 		}
 	
@@ -490,6 +492,7 @@ protected:
 	  bool                                  m_use_relplan;
   	  Fluent_Vec*                           m_goals;
 	  bool					m_verbose;
+	  bool					m_init_pruned;
 };
 
 }

--- a/planners/siw_plus-then-bfs_f-ffparser/src/main.cxx
+++ b/planners/siw_plus-then-bfs_f-ffparser/src/main.cxx
@@ -221,7 +221,7 @@ bool do_siw_search( Search_Engine& engine, STRIPS_Problem& plan_prob, float boun
 	
 	bool foundSol = false;
 
-	if ( engine.find_solution( cost, plan ) ) {
+	if ( !engine.init_pruned() && engine.find_solution( cost, plan ) ) {
 		details << "Plan found with cost: " << cost << std::endl;
 		std::cout << "Plan found with cost: " << cost << std::endl;
 		for ( unsigned k = 0; k < plan.size(); k++ ) {


### PR DESCRIPTION
Issue occurs when the SIW phase detects the init state as unsolvable, and bfsf is just fine finding a solution. Segfaults when it tries to execute the search (since the init state is pruned).